### PR TITLE
fix: Set arogic-mcp-server as default

### DIFF
--- a/lib/context/mcp-context.tsx
+++ b/lib/context/mcp-context.tsx
@@ -59,14 +59,14 @@ export function MCPProvider(props: { children: React.ReactNode }) {
       searchParams.get("useAgoricWebsiteMCP") || "",
     ).toLowerCase() === "true";
 
-  const isThemeYmax = decodeURIComponent(
+  const useYmaxMCP = decodeURIComponent(
     searchParams.get("theme") || "",
   ).toLowerCase() === "ymax";
 
   if (useAgoricWebsiteMCP) {
     DEFAULT_MCP_SERVER.url =
       "https://agoric-mcp-devops-server.agoric-core.workers.dev/sse";
-  } else if (isThemeYmax) {
+  } else if (useYmaxMCP) {
     DEFAULT_MCP_SERVER.name = "Ymax MCP Server";
     DEFAULT_MCP_SERVER.url =
       "https://ymax-mcp-server.agoric-core.workers.dev/sse";


### PR DESCRIPTION
As agoric-mcp-server uses three different MCP servers depending upon query params. This PR will select and choose appropriate MCP depending upon query params. 
The need arises as we have provided tool schemas of agoric-mcp-server to chat/route (the route uses when no query params provided). So technically the default server would be agoric-mcp-server (earlier it was ymax-mcp-server). The issue was found during local development when chat/route route was not listing the tools it's supposed to use. 