### PR TITLE
feat(ymax,support,chat): Add Domain-specific Web Tool Restrictions

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -340,8 +340,13 @@ export async function POST(req: Request) {
 
     Multiple tools can be used in a single response and multiple steps can be used to answer the user's question.
 
-    When a tool is used to generate code (workflow), do not move to next step until the code accepted by the user. 
+    When a tool is used to generate code (workflow), do not move to next step until the code accepted by the user.
     User may review the code and edit it before accepting it, and might give you edited code back to use.
+
+    ## Web tool usage restrictions
+    - Use web_search and web_fetch ONLY for Agoric/blockchain domain queries: Agoric orchestration, IBC transfers, smart contracts, cross-chain operations, Cosmos ecosystem, blockchain explorers, network status, technical documentation, and security information.
+    - NEVER use for: general knowledge, news, entertainment, politics, personal information, or non-blockchain topics.
+    - For out-of-scope queries, decline with: "I'm an Agoric Orchestration assistant specialized in multi-chain operations and Agoric ecosystem. For non-blockchain questions, please use a general-purpose assistant."
 
     ## Response Format
     - Markdown is supported.

--- a/app/api/support/route.ts
+++ b/app/api/support/route.ts
@@ -361,29 +361,10 @@ export async function POST(req: Request) {
     - Politely refuse to know the answer if the question is financial advice.
     - If there's no relevant information gathered from contextual docs and MCP tools, suggest to tag an Agoric admin on discord or contact Agoric support.
 
-    # Web search & web fetch tool usage restrictions
-    - The web_search and web_fetch tools are provided ONLY to enhance your Fast USDC and Agoric blockchain expertise.
-    - **ONLY** use these tools for queries directly related to:
-      - Fast USDC protocol, transactions, and technical operations
-      - CCTP (Cross-Chain Transfer Protocol) and Noble blockchain operations
-      - Agoric blockchain network status and operations
-      - IBC (Inter-Blockchain Communication) relaying and PFM (Packet Forward Middleware)
-      - OCW (Off-Chain Worker) operations and monitoring
-      - USDC bridging, settlement, and liquidity pool operations
-      - Blockchain explorer data for Agoric, Noble, and related chains
-      - Transaction status lookups on relevant blockchain networks
-      - Technical documentation for Agoric ecosystem components
-      - Smart contract addresses and deployment information for Fast USDC
-      - Network issues, gas fees, or validator status for Agoric/Noble chains
-      - Security incidents or exploits related to Fast USDC or Agoric
-    - **NEVER** use web_search or web_fetch for:
-      - General knowledge questions unrelated to Fast USDC/Agoric
-      - News, entertainment, sports, politics, or other non-blockchain topics
-      - Personal information lookups
-      - Any topic outside Fast USDC operations, Agoric blockchain, and related infrastructure
-    - **Response to out-of-scope queries**: If asked about topics outside your Fast USDC/Agoric domain, politely decline with:
-      "I'm a Fast USDC support bot specialized in helping with Fast USDC transactions, troubleshooting, and Agoric blockchain operations. I can only assist with queries related to Fast USDC protocol, transaction diagnostics, and Agoric ecosystem operations. For questions outside this domain, please contact general Agoric support or tag an admin on Discord."
-    - Do not attempt to use web tools to answer out-of-scope questions, even if you think the information might be helpful.
+    ## Web tool usage restrictions
+    - Use web_search and web_fetch ONLY for Fast USDC/Agoric domain queries: Fast USDC transactions, CCTP, Noble, IBC relaying, PFM, OCW monitoring, USDC bridging, blockchain explorers (Agoric/Noble/related chains), transaction status, technical documentation, smart contract addresses, network status, and security incidents.
+    - NEVER use for: general knowledge, news, entertainment, politics, personal information, or non-blockchain topics.
+    - For out-of-scope queries: decline as per Input/Output Guardrails above and suggest contacting Agoric support.
 
     ---
 

--- a/app/api/support/route.ts
+++ b/app/api/support/route.ts
@@ -361,6 +361,30 @@ export async function POST(req: Request) {
     - Politely refuse to know the answer if the question is financial advice.
     - If there's no relevant information gathered from contextual docs and MCP tools, suggest to tag an Agoric admin on discord or contact Agoric support.
 
+    # Web search & web fetch tool usage restrictions
+    - The web_search and web_fetch tools are provided ONLY to enhance your Fast USDC and Agoric blockchain expertise.
+    - **ONLY** use these tools for queries directly related to:
+      - Fast USDC protocol, transactions, and technical operations
+      - CCTP (Cross-Chain Transfer Protocol) and Noble blockchain operations
+      - Agoric blockchain network status and operations
+      - IBC (Inter-Blockchain Communication) relaying and PFM (Packet Forward Middleware)
+      - OCW (Off-Chain Worker) operations and monitoring
+      - USDC bridging, settlement, and liquidity pool operations
+      - Blockchain explorer data for Agoric, Noble, and related chains
+      - Transaction status lookups on relevant blockchain networks
+      - Technical documentation for Agoric ecosystem components
+      - Smart contract addresses and deployment information for Fast USDC
+      - Network issues, gas fees, or validator status for Agoric/Noble chains
+      - Security incidents or exploits related to Fast USDC or Agoric
+    - **NEVER** use web_search or web_fetch for:
+      - General knowledge questions unrelated to Fast USDC/Agoric
+      - News, entertainment, sports, politics, or other non-blockchain topics
+      - Personal information lookups
+      - Any topic outside Fast USDC operations, Agoric blockchain, and related infrastructure
+    - **Response to out-of-scope queries**: If asked about topics outside your Fast USDC/Agoric domain, politely decline with:
+      "I'm a Fast USDC support bot specialized in helping with Fast USDC transactions, troubleshooting, and Agoric blockchain operations. I can only assist with queries related to Fast USDC protocol, transaction diagnostics, and Agoric ecosystem operations. For questions outside this domain, please contact general Agoric support or tag an admin on Discord."
+    - Do not attempt to use web tools to answer out-of-scope questions, even if you think the information might be helpful.
+
     ---
 
     ## Response Templates

--- a/app/api/ymax/route.ts
+++ b/app/api/ymax/route.ts
@@ -376,24 +376,11 @@ export async function POST(req: Request) {
   (1) Use ONLY these three official support channels - no emails, phone numbers, third-party sites, or unofficial Discord servers
   (2) Never fabricate support channels or contact methods
   (3) Default to Discord for any uncertainty or time-sensitive matters
-  # Web search & web fetch tool usage restrictions
-  - The web_search and web_fetch tools are provided ONLY to enhance your DeFi domain expertise.
-  - **ONLY** use these tools for queries directly related to:
-    - DeFi protocols, pools, and yield farming platforms
-    - Blockchain networks, bridges, and cross-chain technology (CCTP, Axelar, IBC, etc.)
-    - Cryptocurrency prices, market data, and DeFi-related news
-    - Protocol documentation, smart contract addresses, and blockchain explorers
-    - APY rates, TVL data, liquidity information for DeFi protocols
-    - Transaction status, gas fees, and blockchain network conditions
-    - Security audits, exploits, or risk information for DeFi protocols
-  - **NEVER** use web_search or web_fetch for:
-    - General knowledge questions unrelated to DeFi/blockchain
-    - News, entertainment, sports, politics, or other non-DeFi topics
-    - Personal information lookups
-    - Any topic outside cryptocurrency, DeFi, and blockchain operations
-  - **Response to out-of-scope queries**: If asked about topics outside your DeFi/blockchain domain, politely decline with:
-    "I'm Max AI, specialized in DeFi portfolio management and blockchain operations through Ymax. I can only assist with queries related to DeFi protocols, yield optimization, transaction tracking, and blockchain operations. For questions outside this domain, please use a general-purpose assistant."
-  - Do not attempt to use web tools to answer out-of-scope questions, even if you think the information might be helpful.
+
+  # Web tool usage restrictions
+  - Use web_search and web_fetch ONLY for DeFi/blockchain domain queries: DeFi protocols, yield farming, blockchain networks, bridges (CCTP, Axelar, IBC), crypto prices, market data, protocol documentation, smart contract addresses, blockchain explorers, APY/TVL data, transaction status, gas fees, network conditions, and security audits.
+  - NEVER use for: general knowledge, news, entertainment, politics, personal information, or non-DeFi topics.
+  - For out-of-scope queries: politely decline per Safety & content rules above and direct to general-purpose assistant.
 
   # Session opener
   Begin the first response with the disclaimer, then proceed directly with the data you can access via Ymax.

--- a/app/api/ymax/route.ts
+++ b/app/api/ymax/route.ts
@@ -380,7 +380,7 @@ export async function POST(req: Request) {
   # Web tool usage restrictions
   - Use web_search and web_fetch ONLY for DeFi/blockchain domain queries: DeFi protocols, yield farming, blockchain networks, bridges (CCTP, Axelar, IBC), crypto prices, market data, protocol documentation, smart contract addresses, blockchain explorers, APY/TVL data, transaction status, gas fees, network conditions, and security audits.
   - NEVER use for: general knowledge, news, entertainment, politics, personal information, or non-DeFi topics.
-  - For out-of-scope queries: politely decline per Safety & content rules above and direct to general-purpose assistant.
+  - For out-of-scope queries: politely decline per Safety & content rules above.
 
   # Session opener
   Begin the first response with the disclaimer, then proceed directly with the data you can access via Ymax.

--- a/app/api/ymax/route.ts
+++ b/app/api/ymax/route.ts
@@ -376,6 +376,24 @@ export async function POST(req: Request) {
   (1) Use ONLY these three official support channels - no emails, phone numbers, third-party sites, or unofficial Discord servers
   (2) Never fabricate support channels or contact methods
   (3) Default to Discord for any uncertainty or time-sensitive matters
+  # Web search & web fetch tool usage restrictions
+  - The web_search and web_fetch tools are provided ONLY to enhance your DeFi domain expertise.
+  - **ONLY** use these tools for queries directly related to:
+    - DeFi protocols, pools, and yield farming platforms
+    - Blockchain networks, bridges, and cross-chain technology (CCTP, Axelar, IBC, etc.)
+    - Cryptocurrency prices, market data, and DeFi-related news
+    - Protocol documentation, smart contract addresses, and blockchain explorers
+    - APY rates, TVL data, liquidity information for DeFi protocols
+    - Transaction status, gas fees, and blockchain network conditions
+    - Security audits, exploits, or risk information for DeFi protocols
+  - **NEVER** use web_search or web_fetch for:
+    - General knowledge questions unrelated to DeFi/blockchain
+    - News, entertainment, sports, politics, or other non-DeFi topics
+    - Personal information lookups
+    - Any topic outside cryptocurrency, DeFi, and blockchain operations
+  - **Response to out-of-scope queries**: If asked about topics outside your DeFi/blockchain domain, politely decline with:
+    "I'm Max AI, specialized in DeFi portfolio management and blockchain operations through Ymax. I can only assist with queries related to DeFi protocols, yield optimization, transaction tracking, and blockchain operations. For questions outside this domain, please use a general-purpose assistant."
+  - Do not attempt to use web tools to answer out-of-scope questions, even if you think the information might be helpful.
 
   # Session opener
   Begin the first response with the disclaimer, then proceed directly with the data you can access via Ymax.


### PR DESCRIPTION
**Why this change is needed**
After implementing web_search and web_fetch tools, our chat assistants (sometimes) bring information from the web using these tools that is beyond their scope/domain. This PR addresses the issue. 

**POC**
https://www.loom.com/share/2bca193cc84f4bfabf0659c81b050f34