### PR TITLE
chore: Add modular validation system for API routes leading to integration tests

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -10,6 +10,13 @@ import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
 import { spawn } from "child_process";
 import { agoricMcpToolSchemas } from "@/lib/mcp/agoric-tool-schemas";
 import { addAnthropicWebTools } from '@/lib/ai/anthropic-web-tools';
+import {
+  validateUserId,
+  validateMessages,
+  validateSelectedModel,
+  validateMessageStructure,
+  type ChatRequestBody
+} from '@/lib/validation/chat-validation';
 
 // Allow streaming responses up to 30 seconds
 export const maxDuration = 120;
@@ -34,26 +41,54 @@ export async function POST(req: Request) {
   const contextParam = url.searchParams.get('context');
   const inoParam = url.searchParams.get('ino');
 
+  const body = await req.json() as ChatRequestBody;
+
+  // Validate request using individual validators
+  const userIdError = validateUserId(body);
+  if (userIdError) {
+    return new Response(
+      JSON.stringify({ error: userIdError.error }),
+      { status: userIdError.status, headers: { "Content-Type": "application/json" } }
+    );
+  }
+
+  const messagesError = validateMessages(body);
+  if (messagesError) {
+    return new Response(
+      JSON.stringify({ error: messagesError.error }),
+      { status: messagesError.status, headers: { "Content-Type": "application/json" } }
+    );
+  }
+
+  const selectedModelError = validateSelectedModel(body);
+  if (selectedModelError) {
+    return new Response(
+      JSON.stringify({ error: selectedModelError.error }),
+      { status: selectedModelError.status, headers: { "Content-Type": "application/json" } }
+    );
+  }
+
+  const messageStructureError = validateMessageStructure(body);
+  if (messageStructureError) {
+    return new Response(
+      JSON.stringify({ error: messageStructureError.error }),
+      { status: messageStructureError.status, headers: { "Content-Type": "application/json" } }
+    );
+  }
+
   const {
     messages,
     chatId,
     selectedModel,
     userId,
     mcpServers = [],
-  }: {
+  } = body as {
     messages: UIMessage[];
     chatId?: string;
     selectedModel: modelID;
     userId: string;
     mcpServers?: MCPServerConfig[];
-  } = await req.json();
-
-  if (!userId) {
-    return new Response(
-      JSON.stringify({ error: "User ID is required" }),
-      { status: 400, headers: { "Content-Type": "application/json" } }
-    );
-  }
+  };
 
   const id = chatId || nanoid();
 

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -15,6 +15,8 @@ import {
   validateMessages,
   validateSelectedModel,
   validateMessageStructure,
+  validateMcpServer,
+  EXPECTED_MCP_SERVERS,
   type ChatRequestBody
 } from '@/lib/validation/chat-validation';
 
@@ -73,6 +75,14 @@ export async function POST(req: Request) {
     return new Response(
       JSON.stringify({ error: messageStructureError.error }),
       { status: messageStructureError.status, headers: { "Content-Type": "application/json" } }
+    );
+  }
+
+  const mcpServerError = validateMcpServer(body, EXPECTED_MCP_SERVERS.CHAT);
+  if (mcpServerError) {
+    return new Response(
+      JSON.stringify({ error: mcpServerError.error }),
+      { status: mcpServerError.status, headers: { "Content-Type": "application/json" } }
     );
   }
 

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -45,7 +45,6 @@ export async function POST(req: Request) {
 
   const body = await req.json() as ChatRequestBody;
 
-  // Validate request using individual validators
   const userIdError = validateUserId(body);
   if (userIdError) {
     return new Response(

--- a/app/api/support/route.ts
+++ b/app/api/support/route.ts
@@ -18,6 +18,8 @@ import {
   validateMessages,
   validateSelectedModel,
   validateMessageStructure,
+  validateMcpServer,
+  EXPECTED_MCP_SERVERS,
   type ChatRequestBody
 } from '@/lib/validation/chat-validation';
 
@@ -75,6 +77,14 @@ export async function POST(req: Request) {
     return new Response(
       JSON.stringify({ error: messageStructureError.error }),
       { status: messageStructureError.status, headers: { "Content-Type": "application/json" } }
+    );
+  }
+
+  const mcpServerError = validateMcpServer(body, EXPECTED_MCP_SERVERS.SUPPORT);
+  if (mcpServerError) {
+    return new Response(
+      JSON.stringify({ error: mcpServerError.error }),
+      { status: mcpServerError.status, headers: { "Content-Type": "application/json" } }
     );
   }
 

--- a/app/api/support/route.ts
+++ b/app/api/support/route.ts
@@ -47,7 +47,6 @@ export async function POST(req: Request) {
 
   const body = await req.json() as ChatRequestBody;
 
-  // Validate request using individual validators
   const userIdError = validateUserId(body);
   if (userIdError) {
     return new Response(

--- a/app/api/support/route.ts
+++ b/app/api/support/route.ts
@@ -13,6 +13,13 @@ import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js"
 import { spawn } from "child_process";
 import { agoricMcpDevopsToolSchemas } from "@/lib/mcp/agoric-devops-tool-schemas";
 import { addAnthropicWebTools } from '@/lib/ai/anthropic-web-tools';
+import {
+  validateUserId,
+  validateMessages,
+  validateSelectedModel,
+  validateMessageStructure,
+  type ChatRequestBody
+} from '@/lib/validation/chat-validation';
 
 // Allow streaming responses up to 30 seconds
 export const maxDuration = 120;
@@ -36,26 +43,54 @@ export async function POST(req: Request) {
   const url = new URL(req.url);
   const contextParam = url.searchParams.get("context");
 
+  const body = await req.json() as ChatRequestBody;
+
+  // Validate request using individual validators
+  const userIdError = validateUserId(body);
+  if (userIdError) {
+    return new Response(
+      JSON.stringify({ error: userIdError.error }),
+      { status: userIdError.status, headers: { "Content-Type": "application/json" } }
+    );
+  }
+
+  const messagesError = validateMessages(body);
+  if (messagesError) {
+    return new Response(
+      JSON.stringify({ error: messagesError.error }),
+      { status: messagesError.status, headers: { "Content-Type": "application/json" } }
+    );
+  }
+
+  const selectedModelError = validateSelectedModel(body);
+  if (selectedModelError) {
+    return new Response(
+      JSON.stringify({ error: selectedModelError.error }),
+      { status: selectedModelError.status, headers: { "Content-Type": "application/json" } }
+    );
+  }
+
+  const messageStructureError = validateMessageStructure(body);
+  if (messageStructureError) {
+    return new Response(
+      JSON.stringify({ error: messageStructureError.error }),
+      { status: messageStructureError.status, headers: { "Content-Type": "application/json" } }
+    );
+  }
+
   const {
     messages,
     chatId,
     selectedModel,
     userId,
     mcpServers = [],
-  }: {
+  } = body as {
     messages: UIMessage[];
     chatId?: string;
     selectedModel: modelID;
     userId: string;
     mcpServers?: MCPServerConfig[];
-  } = await req.json();
-
-  if (!userId) {
-    return new Response(JSON.stringify({ error: "User ID is required" }), {
-      status: 400,
-      headers: { "Content-Type": "application/json" },
-    });
-  }
+  };
 
   const id = chatId || nanoid();
 

--- a/app/api/ymax/route.ts
+++ b/app/api/ymax/route.ts
@@ -48,7 +48,6 @@ export async function POST(req: Request) {
 
   const body = await req.json() as ChatRequestBody;
 
-  // Validate request using individual validators
   const userIdError = validateUserId(body);
   if (userIdError) {
     return new Response(

--- a/app/api/ymax/route.ts
+++ b/app/api/ymax/route.ts
@@ -19,6 +19,8 @@ import {
   validateMessages,
   validateSelectedModel,
   validateMessageStructure,
+  validateMcpServer,
+  EXPECTED_MCP_SERVERS,
   type ChatRequestBody
 } from '@/lib/validation/chat-validation';
 
@@ -76,6 +78,14 @@ export async function POST(req: Request) {
     return new Response(
       JSON.stringify({ error: messageStructureError.error }),
       { status: messageStructureError.status, headers: { "Content-Type": "application/json" } }
+    );
+  }
+
+  const mcpServerError = validateMcpServer(body, EXPECTED_MCP_SERVERS.YMAX);
+  if (mcpServerError) {
+    return new Response(
+      JSON.stringify({ error: mcpServerError.error }),
+      { status: mcpServerError.status, headers: { "Content-Type": "application/json" } }
     );
   }
 

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -3,7 +3,7 @@
 import { defaultModel, type modelID } from "@/ai/providers";
 import { UIMessage, useChat } from "@ai-sdk/react";
 import { DefaultChatTransport } from "ai";
-import { useState, useEffect, useCallback, Suspense } from "react";
+import { useState, useEffect, useCallback, Suspense, useRef } from "react";
 import { Textarea } from "./textarea";
 import { ProjectOverview } from "./project-overview";
 import { Messages } from "./messages";
@@ -50,6 +50,14 @@ function ChatContent() {
 
   // Get MCP server data from context
   const { mcpServersForApi } = useMCP();
+
+  // Use a ref to always have the latest mcpServersForApi value in the closure
+  const mcpServersForApiRef = useRef(mcpServersForApi);
+
+  // Update ref whenever mcpServersForApi changes
+  useEffect(() => {
+    mcpServersForApiRef.current = mcpServersForApi;
+  }, [mcpServersForApi]);
 
   // Get the editor context
   const { submittedCode, editorLanguage, submissionKey, clearSubmittedCode } =
@@ -113,11 +121,12 @@ function ChatContent() {
     transport: new DefaultChatTransport({
       api: apiUrl,
       prepareSendMessagesRequest({ messages }) {
+        // Use ref.current to get the latest value, not the closure-captured value
         return {
           body: {
             messages,
             selectedModel,
-            mcpServers: mcpServersForApi,
+            mcpServers: mcpServersForApiRef.current,
             chatId: chatId || generatedChatId,
             userId,
           },

--- a/lib/context/mcp-context.tsx
+++ b/lib/context/mcp-context.tsx
@@ -110,7 +110,7 @@ export function MCPProvider(props: { children: React.ReactNode }) {
       }));
 
     setMcpServersForApi(processedServers);
-  }, [mcpServers, selectedMcpServers]);
+  }, [_mcpServers, _selectedMcpServers, mcpServers, selectedMcpServers]);
 
   return (
     <MCPContext.Provider

--- a/lib/validation/chat-validation.ts
+++ b/lib/validation/chat-validation.ts
@@ -22,7 +22,7 @@
  * IMPORTANT: Any changes to validation logic should be made HERE, not in individual route files.
  */
 
-import { MODELS } from '@/ai/providers';
+import { MODELS, type modelID } from '@/ai/providers';
 
 export const EXPECTED_MCP_SERVERS = {
   CHAT: 'https://agoric-mcp-server.agoric-core.workers.dev/sse',
@@ -37,6 +37,7 @@ export interface ValidationError {
 
 /**
  * Message part structure from AI SDK
+ * Simplified version matching UIMessagePart
  */
 interface MessagePart {
   type: string;
@@ -46,38 +47,34 @@ interface MessagePart {
 
 /**
  * Message structure from AI SDK
+ * Simplified version matching UIMessage interface
  */
 interface Message {
+  id?: string;  // Optional for backwards compatibility
   role: string;
   parts: MessagePart[];
+  metadata?: unknown;
   [key: string]: unknown;
 }
 
 /**
  * Request body structure for chat API endpoints
+ *
+ * Required fields are validated by their respective validator functions:
+ * - userId: validateUserId()
+ * - messages: validateMessages() and validateMessageStructure()
+ * - selectedModel: validateSelectedModel()
+ *
+ * Optional fields have runtime defaults:
+ * - chatId: falls back to nanoid() if not provided
+ * - mcpServers: defaults to [] if not provided
  */
 export interface ChatRequestBody {
-  userId?: string;
-  messages?: unknown;
-  selectedModel?: string;
+  userId: string;
+  messages: unknown;
+  selectedModel: modelID;
   chatId?: string;
   mcpServers?: unknown[];
-}
-
-/**
- * Validates that the request body is a valid object
- *
- * @param body - The request body to validate
- * @returns ValidationError if body is not an object, null if valid
- */
-export function validateRequestBody(body: unknown): ValidationError | null {
-  if (!body || typeof body !== 'object') {
-    return {
-      error: 'Request body must be an object',
-      status: 400
-    };
-  }
-  return null;
 }
 
 /**
@@ -90,23 +87,6 @@ export function validateUserId(body: ChatRequestBody): ValidationError | null {
   if (!body.userId || typeof body.userId !== 'string') {
     return {
       error: 'User ID is required',
-      status: 400
-    };
-  }
-
-  return null;
-}
-
-/**
- * Validates that messages field is an array
- *
- * @param body - The request body containing messages
- * @returns ValidationError if messages is missing or not an array, null if valid
- */
-export function validateMessages(body: ChatRequestBody): ValidationError | null {
-  if (!body.messages || !Array.isArray(body.messages)) {
-    return {
-      error: 'Messages must be an array',
       status: 400
     };
   }
@@ -128,7 +108,6 @@ export function validateSelectedModel(body: ChatRequestBody): ValidationError | 
     };
   }
 
-  // Check if selectedModel is a valid model ID
   if (!MODELS.includes(body.selectedModel)) {
     return {
       error: `Invalid model: ${body.selectedModel}. Valid models are: ${MODELS.join(', ')}`,
@@ -138,6 +117,72 @@ export function validateSelectedModel(body: ChatRequestBody): ValidationError | 
 
   return null;
 }
+/**
+ * Validates that messages field is an array
+ *
+ * @param body - The request body containing messages
+ * @returns ValidationError if messages is missing or not an array, null if valid
+ */
+export function validateMessages(body: ChatRequestBody): ValidationError | null {
+  if (!body.messages || !Array.isArray(body.messages)) {
+    return {
+      error: 'Messages must be an array',
+      status: 400
+    };
+  }
+
+  return null;
+}
+
+
+/**
+ * Type guard to check if a value is a valid MessagePart
+ */
+function isMessagePart(value: unknown): value is MessagePart {
+  return (
+    value !== null &&
+    typeof value === 'object' &&
+    !Array.isArray(value) &&
+    'type' in value &&
+    typeof (value as MessagePart).type === 'string'
+  );
+}
+
+/**
+ * Type guard to check if a value is a valid Message
+ */
+function isMessage(value: unknown): value is Message {
+  if (
+    value === null ||
+    typeof value !== 'object' ||
+    Array.isArray(value)
+  ) {
+    return false;
+  }
+
+  const msg = value as Record<string, unknown>;
+
+  if (
+    !('role' in msg) ||
+    typeof msg.role !== 'string' ||
+    !('parts' in msg) ||
+    !Array.isArray(msg.parts)
+  ) {
+    return false;
+  }
+
+  if (msg.parts.length === 0) {
+    return false;
+  }
+
+  for (const part of msg.parts) {
+    if (!isMessagePart(part)) {
+      return false;
+    }
+  }
+
+  return true;
+}
 
 /**
  * Validates that each message has the required parts array structure
@@ -146,12 +191,70 @@ export function validateSelectedModel(body: ChatRequestBody): ValidationError | 
  * @returns ValidationError if message structure is invalid, null if valid
  */
 export function validateMessageStructure(body: ChatRequestBody): ValidationError | null {
-  const messages = body.messages as Message[];
+  // Defensive: Ensure messages is an array (in case validateMessages wasn't called)
+  if (!Array.isArray(body.messages)) {
+    return {
+      error: 'Messages must be an array',
+      status: 400
+    };
+  }
 
-  for (const msg of messages) {
-    if (!msg.parts || !Array.isArray(msg.parts)) {
+  const messages = body.messages;
+
+  for (let i = 0; i < messages.length; i++) {
+    const msg = messages[i];
+
+    if (!msg || typeof msg !== 'object' || Array.isArray(msg)) {
       return {
-        error: 'Invalid message format: messages must have parts array',
+        error: `Invalid message at index ${i}: must be an object`,
+        status: 400
+      };
+    }
+
+    if (!('role' in msg) || typeof (msg as Record<string, unknown>).role !== 'string') {
+      return {
+        error: `Invalid message at index ${i}: must have role field (string)`,
+        status: 400
+      };
+    }
+
+    if (!('parts' in msg) || !Array.isArray((msg as Record<string, unknown>).parts)) {
+      return {
+        error: `Invalid message at index ${i}: must have parts field (array)`,
+        status: 400
+      };
+    }
+
+    const parts = (msg as Record<string, unknown>).parts as unknown[];
+
+    if (parts.length === 0) {
+      return {
+        error: `Invalid message at index ${i}: parts array cannot be empty`,
+        status: 400
+      };
+    }
+
+    for (let j = 0; j < parts.length; j++) {
+      const part = parts[j];
+
+      if (!part || typeof part !== 'object' || Array.isArray(part)) {
+        return {
+          error: `Invalid message at index ${i}, part ${j}: must be an object`,
+          status: 400
+        };
+      }
+
+      if (!('type' in part) || typeof (part as Record<string, unknown>).type !== 'string') {
+        return {
+          error: `Invalid message at index ${i}, part ${j}: must have type field (string)`,
+          status: 400
+        };
+      }
+    }
+
+    if (!isMessage(msg)) {
+      return {
+        error: `Invalid message at index ${i}: message structure is malformed`,
         status: 400
       };
     }
@@ -160,43 +263,217 @@ export function validateMessageStructure(body: ChatRequestBody): ValidationError
   return null;
 }
 
+/**
+ * MCP Server configuration interface
+ * Matches MCPServerConfig used in API routes
+ */
+interface MCPServerConfig {
+  url: string;
+  type: 'sse' | 'stdio';
+  command?: string;
+  args?: string[];
+  env?: Array<{ key: string; value: string }>;
+  headers?: Array<{ key: string; value: string }>;
+}
+
+/**
+ * Type guard to check if a value is a valid MCPServerConfig
+ */
+function isMCPServerConfig(value: unknown): value is MCPServerConfig {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return false;
+  }
+
+  const server = value as Record<string, unknown>;
+
+  if (
+    !('url' in server) ||
+    typeof server.url !== 'string' ||
+    server.url.trim() === ''
+  ) {
+    return false;
+  }
+
+  if (
+    !('type' in server) ||
+    (server.type !== 'sse' && server.type !== 'stdio')
+  ) {
+    return false;
+  }
+
+  // For stdio type, validate required fields
+  if (server.type === 'stdio') {
+    if (
+      !('command' in server) ||
+      typeof server.command !== 'string' ||
+      server.command.trim() === ''
+    ) {
+      return false;
+    }
+
+    if (
+      !('args' in server) ||
+      !Array.isArray(server.args) ||
+      server.args.length === 0
+    ) {
+      return false;
+    }
+
+    for (const arg of server.args) {
+      if (typeof arg !== 'string') {
+        return false;
+      }
+    }
+  }
+
+  return true;
+}
+
+/**
+ * Normalize URL for comparison (handles trailing slashes, protocol, etc.)
+ */
+function normalizeUrl(url: string): string {
+  try {
+    const parsed = new URL(url);
+    // Remove trailing slash, lowercase hostname
+    const pathname = parsed.pathname.replace(/\/$/, '');
+    return `${parsed.protocol}//${parsed.hostname.toLowerCase()}${pathname}${parsed.search}`;
+  } catch {
+    // Return as-is if invalid URL, let validation catch it
+    return url.trim().toLowerCase();
+  }
+}
+
+/**
+ * Validates that the request contains exactly one MCP server and it matches the expected server
+ *
+ * Security: This enforces a strict one-to-one mapping between routes and MCP servers,
+ * preventing malicious server injection attacks where an attacker could send additional
+ * unauthorized servers alongside the valid one.
+ *
+ * @param body - The request body containing mcpServers array
+ * @param expectedServerUrl - The URL of the MCP server expected for this route
+ * @returns ValidationError if validation fails, null if valid
+ */
 export function validateMcpServer(
   body: ChatRequestBody,
   expectedServerUrl: string
 ): ValidationError | null {
-  const mcpServers = body.mcpServers || [];
+  if (!Array.isArray(body.mcpServers)) {
+    if (body.mcpServers === undefined || body.mcpServers === null) {
+      return {
+        error: `MCP server is required. Expected exactly 1 server: ${expectedServerUrl}`,
+        status: 400
+      };
+    }
 
-  if (mcpServers.length === 0) {
     return {
-      error: `MCP server is required. Expected server: ${expectedServerUrl}`,
+      error: `MCP servers must be an array. Expected exactly 1 server: ${expectedServerUrl}`,
       status: 400
     };
   }
 
-  const hasExpectedServer = mcpServers.some(
-    (server: any) => server.url === expectedServerUrl
-  );
+  const mcpServers = body.mcpServers;
 
-  if (!hasExpectedServer) {
+  if (mcpServers.length === 0) {
     return {
-      error: `Invalid MCP server. Expected: ${expectedServerUrl}`,
+      error: `MCP server is required. Expected exactly 1 server: ${expectedServerUrl}`,
+      status: 400
+    };
+  }
+
+  if (mcpServers.length > 1) {
+    const receivedUrls = mcpServers
+      .filter(isMCPServerConfig)
+      .map(s => s.url)
+      .join(', ');
+
+    return {
+      error: `Expected exactly 1 MCP server for this endpoint, got ${mcpServers.length}. This endpoint only supports: ${expectedServerUrl}. Received: ${receivedUrls}`,
+      status: 400
+    };
+  }
+
+  const server = mcpServers[0];
+
+  if (!server || typeof server !== 'object' || Array.isArray(server)) {
+    return {
+      error: `Invalid MCP server: must be an object`,
+      status: 400
+    };
+  }
+
+  if (!('url' in server) || typeof (server as Record<string, unknown>).url !== 'string') {
+    return {
+      error: `Invalid MCP server: must have url field (string)`,
+      status: 400
+    };
+  }
+
+  const serverUrl = (server as Record<string, unknown>).url as string;
+  if (serverUrl.trim() === '') {
+    return {
+      error: `Invalid MCP server: url cannot be empty`,
+      status: 400
+    };
+  }
+
+  if (!('type' in server)) {
+    return {
+      error: `Invalid MCP server: must have type field ('sse' | 'stdio')`,
+      status: 400
+    };
+  }
+
+  const serverType = (server as Record<string, unknown>).type;
+  if (serverType !== 'sse' && serverType !== 'stdio') {
+    return {
+      error: `Invalid MCP server: type must be 'sse' or 'stdio', got '${serverType}'`,
+      status: 400
+    };
+  }
+
+  // For stdio type, validate required fields
+  if (serverType === 'stdio') {
+    if (!('command' in server) || typeof (server as Record<string, unknown>).command !== 'string') {
+      return {
+        error: `Invalid MCP server: stdio type requires command field (string)`,
+        status: 400
+      };
+    }
+
+    if (!('args' in server) || !Array.isArray((server as Record<string, unknown>).args)) {
+      return {
+        error: `Invalid MCP server: stdio type requires args field (array)`,
+        status: 400
+      };
+    }
+
+    const args = (server as Record<string, unknown>).args as unknown[];
+    if (args.length === 0) {
+      return {
+        error: `Invalid MCP server: stdio args cannot be empty`,
+        status: 400
+      };
+    }
+  }
+
+  if (!isMCPServerConfig(server)) {
+    return {
+      error: `Invalid MCP server: server structure is malformed`,
+      status: 400
+    };
+  }
+
+  const normalizedExpected = normalizeUrl(expectedServerUrl);
+  const normalizedReceived = normalizeUrl(server.url);
+
+  if (normalizedReceived !== normalizedExpected) {
+    return {
+      error: `Invalid MCP server. Expected: ${expectedServerUrl}, but received: ${server.url}`,
       status: 400
     };
   }
 
   return null;
-}
-
-/**
- * Type guard to check if a value is a validation error
- */
-export function isValidationError(value: unknown): value is ValidationError {
-  return (
-    value !== null &&
-    typeof value === 'object' &&
-    'error' in value &&
-    'status' in value &&
-    typeof (value as ValidationError).error === 'string' &&
-    typeof (value as ValidationError).status === 'number'
-  );
 }

--- a/lib/validation/chat-validation.ts
+++ b/lib/validation/chat-validation.ts
@@ -24,6 +24,12 @@
 
 import { MODELS } from '@/ai/providers';
 
+export const EXPECTED_MCP_SERVERS = {
+  CHAT: 'https://agoric-mcp-server.agoric-core.workers.dev/sse',
+  YMAX: 'https://ymax-mcp-server.agoric-core.workers.dev/sse',
+  SUPPORT: 'https://agoric-mcp-devops-server.agoric-core.workers.dev/sse'
+} as const;
+
 export interface ValidationError {
   error: string;
   status: 400 | 401 | 403 | 422;
@@ -149,6 +155,33 @@ export function validateMessageStructure(body: ChatRequestBody): ValidationError
         status: 400
       };
     }
+  }
+
+  return null;
+}
+
+export function validateMcpServer(
+  body: ChatRequestBody,
+  expectedServerUrl: string
+): ValidationError | null {
+  const mcpServers = body.mcpServers || [];
+
+  if (mcpServers.length === 0) {
+    return {
+      error: `MCP server is required. Expected server: ${expectedServerUrl}`,
+      status: 400
+    };
+  }
+
+  const hasExpectedServer = mcpServers.some(
+    (server: any) => server.url === expectedServerUrl
+  );
+
+  if (!hasExpectedServer) {
+    return {
+      error: `Invalid MCP server. Expected: ${expectedServerUrl}`,
+      status: 400
+    };
   }
 
   return null;

--- a/lib/validation/chat-validation.ts
+++ b/lib/validation/chat-validation.ts
@@ -1,0 +1,169 @@
+/**
+ * Shared Validation Logic for Chat API Routes
+ *
+ * PURPOSE OF EXTRACTION:
+ * This validation logic is used by BOTH:
+ * 1. Real API routes (app/api/chat/route.ts, app/api/ymax/route.ts, app/api/support/route.ts)
+ * 2. Test mocks (test/setup.ts - MSW handlers)
+ *
+ * By extracting validation into shared functions, we ensure:
+ * - Single source of truth for validation rules
+ * - Tests automatically stay in sync with API changes
+ * - If a developer changes validation logic here, both API and tests update together
+ * - Impossible for tests to return different status codes than real API
+ *
+ * ARCHITECTURE:
+ * Each validation concern is separated into its own function for:
+ * - Better modularity and reusability
+ * - Easier testing of individual validators
+ * - Ability to compose validators based on endpoint needs
+ * - Future extensibility (add new validators without modifying existing ones)
+ *
+ * IMPORTANT: Any changes to validation logic should be made HERE, not in individual route files.
+ */
+
+import { MODELS } from '@/ai/providers';
+
+export interface ValidationError {
+  error: string;
+  status: 400 | 401 | 403 | 422;
+}
+
+/**
+ * Message part structure from AI SDK
+ */
+interface MessagePart {
+  type: string;
+  text?: string;
+  [key: string]: unknown;
+}
+
+/**
+ * Message structure from AI SDK
+ */
+interface Message {
+  role: string;
+  parts: MessagePart[];
+  [key: string]: unknown;
+}
+
+/**
+ * Request body structure for chat API endpoints
+ */
+export interface ChatRequestBody {
+  userId?: string;
+  messages?: unknown;
+  selectedModel?: string;
+  chatId?: string;
+  mcpServers?: unknown[];
+}
+
+/**
+ * Validates that the request body is a valid object
+ *
+ * @param body - The request body to validate
+ * @returns ValidationError if body is not an object, null if valid
+ */
+export function validateRequestBody(body: unknown): ValidationError | null {
+  if (!body || typeof body !== 'object') {
+    return {
+      error: 'Request body must be an object',
+      status: 400
+    };
+  }
+  return null;
+}
+
+/**
+ * Validates that userId is present and is a string
+ *
+ * @param body - The request body containing userId
+ * @returns ValidationError if userId is missing or invalid, null if valid
+ */
+export function validateUserId(body: ChatRequestBody): ValidationError | null {
+  if (!body.userId || typeof body.userId !== 'string') {
+    return {
+      error: 'User ID is required',
+      status: 400
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Validates that messages field is an array
+ *
+ * @param body - The request body containing messages
+ * @returns ValidationError if messages is missing or not an array, null if valid
+ */
+export function validateMessages(body: ChatRequestBody): ValidationError | null {
+  if (!body.messages || !Array.isArray(body.messages)) {
+    return {
+      error: 'Messages must be an array',
+      status: 400
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Validates that selectedModel is present and is a valid model ID
+ *
+ * @param body - The request body containing selectedModel
+ * @returns ValidationError if selectedModel is missing or invalid, null if valid
+ */
+export function validateSelectedModel(body: ChatRequestBody): ValidationError | null {
+  if (!body.selectedModel || typeof body.selectedModel !== 'string') {
+    return {
+      error: 'selectedModel is required',
+      status: 400
+    };
+  }
+
+  // Check if selectedModel is a valid model ID
+  if (!MODELS.includes(body.selectedModel)) {
+    return {
+      error: `Invalid model: ${body.selectedModel}. Valid models are: ${MODELS.join(', ')}`,
+      status: 400
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Validates that each message has the required parts array structure
+ *
+ * @param body - The request body containing messages
+ * @returns ValidationError if message structure is invalid, null if valid
+ */
+export function validateMessageStructure(body: ChatRequestBody): ValidationError | null {
+  const messages = body.messages as Message[];
+
+  for (const msg of messages) {
+    if (!msg.parts || !Array.isArray(msg.parts)) {
+      return {
+        error: 'Invalid message format: messages must have parts array',
+        status: 400
+      };
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Type guard to check if a value is a validation error
+ */
+export function isValidationError(value: unknown): value is ValidationError {
+  return (
+    value !== null &&
+    typeof value === 'object' &&
+    'error' in value &&
+    'status' in value &&
+    typeof (value as ValidationError).error === 'string' &&
+    typeof (value as ValidationError).status === 'number'
+  );
+}


### PR DESCRIPTION
### Purpose of this PR

1. **Shared Validation Logic for Chat API Routes**
2. **PURPOSE OF EXTRACTION:**
The validation logic is used by BOTH:
-Real API routes (app/api/chat/route.ts, app/api/ymax/route.ts, app/api/support/route.ts)
-(in the subsequent PR)Test mocks (test/setup.ts - MSW handlers)

3. **By extracting validation into shared functions, we ensure:**
 - Single source of truth for validation rules
 - Tests automatically stay in sync with API changes
 - If a developer changes validation logic here, both API and tests update together
 -  Impossible for tests to return different status codes than real API
 
 4. **ARCHITECTURE:**
 Each validation concern is separated into its own function for:
  - Better modularity and reusability
  - Easier testing of individual validators
  - Ability to compose validators based on endpoint needs
  - Future extensibility (add new validators without modifying existing ones)

5. **This PR also fixes an existing but of not picking up the MCP server on the chat/[id] route if the page is hard-refreshed. Reason of doing in this PR is that while validating the correct MCP (during development) the prescribed route giving an error ** 
