### PR TITLE
refactor(chat.tsx): made a chat.utils and its related (unit) tests

### DIFF
--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -13,6 +13,16 @@ import { getUserId } from "@/lib/user-id";
 import { useLocalStorage } from "@/lib/hooks/use-local-storage";
 import { STORAGE_KEYS } from "@/lib/constants";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  getApiBase,
+  buildApiUrl,
+  decodeTitle,
+  isLoadingState,
+  parseMessageData,
+  isOrbitChatSubmission,
+  shouldSubmitCode,
+  buildChatUrl,
+} from "@/lib/chat-utils";
 // import { convertToUIMessages } from "@/lib/chat-store";
 import { type Message as DBMessage } from "@/lib/db/schema";
 import { nanoid } from "nanoid";
@@ -38,7 +48,7 @@ function ChatContent() {
   const contextParam = searchParams.get("context");
   const titleParam = searchParams.get("title");
   const disableAutoFocus = !!searchParams.get("disableAutoFocus");
-  const title = titleParam ? decodeURIComponent(titleParam) : "Agoric AI Chat";
+  const title = decodeTitle(titleParam);
   const queryClient = useQueryClient();
 
   const [selectedModel, setSelectedModel] = useLocalStorage<modelID>(
@@ -89,16 +99,8 @@ function ChatContent() {
   const useAgoricWebsiteMCP = searchParams.get("useAgoricWebsiteMCP");
   const theme = searchParams.get("theme");
 
-  let apiBase = "/api/chat"; // default
-  if (useAgoricWebsiteMCP) {
-    apiBase = "/api/support";
-  } else if (theme === "ymax") {
-    apiBase = "/api/ymax";
-  }
-
-  const apiUrl = newParams.toString()
-    ? `${apiBase}?${newParams.toString()}`
-    : apiBase;
+  const apiBase = getApiBase(useAgoricWebsiteMCP, theme);
+  const apiUrl = buildApiUrl(apiBase, newParams);
 
   // Manage input state manually in v5
   const [input, setInput] = useState("");
@@ -143,7 +145,7 @@ function ChatContent() {
   });
 
   // Define loading state early so it can be used in effects
-  const isLoading = status === "streaming" || status === "submitted";
+  const isLoading = isLoadingState(status);
 
   // Custom submit handler - Define this BEFORE using it in the effect
   const handleFormSubmit = useCallback(
@@ -158,10 +160,9 @@ function ChatContent() {
       // If this is a new conversation, update the URL without causing a remount
       if (!chatId && generatedChatId) {
         // Preserve all query parameters in navigation
-        const searchParams = new URLSearchParams(window.location.search);
-        const queryString = searchParams.toString();
-        const queryQuery = queryString ? `?${queryString}` : "";
-        window.history.replaceState({}, '', `/chat/${generatedChatId}${queryQuery}`);
+        const currentSearchParams = new URLSearchParams(window.location.search);
+        const newUrl = buildChatUrl(generatedChatId, currentSearchParams);
+        window.history.replaceState({}, '', newUrl);
       }
     },
     [chatId, generatedChatId, input, sendMessage],
@@ -176,20 +177,11 @@ function ChatContent() {
   const [lastSubmittedKey, setLastSubmittedKey] = useState<number>(0);
 
   useEffect(() => {
-    async function onMessage(e: MessageEvent) {
-      const data =
-        typeof e.data === "string"
-          ? (() => {
-            try {
-              return JSON.parse(e.data);
-            } catch {
-              return e.data;
-            }
-          })()
-          : e.data;
+    function onMessage(e: MessageEvent) {
+      const data = parseMessageData(e.data);
 
-      if (data?.type === "ORBIT_CHAT/SET_AND_SUBMIT") {
-        const text = data?.payload?.input ?? "";
+      if (isOrbitChatSubmission(data)) {
+        const text = data.payload.input;
         if (text) {
           sendMessage({ text });
         }
@@ -197,7 +189,7 @@ function ChatContent() {
     }
     window.addEventListener("message", onMessage);
     return () => window.removeEventListener("message", onMessage);
-  }, []);
+  }, [sendMessage]);
 
   // Listen for submitted code and send it to the chat
   useEffect(() => {
@@ -210,16 +202,8 @@ function ChatContent() {
       lastSubmittedKey,
     );
 
-    // Only proceed if:
-    // 1. There's submitted code
-    // 2. Valid submission key that's different from the last one we processed
-    // 3. Not already loading
-    if (
-      submittedCode &&
-      submissionKey > 0 &&
-      submissionKey !== lastSubmittedKey &&
-      !isLoading
-    ) {
+    // Only proceed if conditions are met for code submission
+    if (shouldSubmitCode(submittedCode, submissionKey, lastSubmittedKey, isLoading)) {
       console.log(
         "CHAT: Preparing to submit code to chat, key changed:",
         submissionKey,

--- a/lib/chat-utils.ts
+++ b/lib/chat-utils.ts
@@ -1,0 +1,112 @@
+/**
+ * Utility functions extracted from chat.tsx for testability
+ * Only contains actual business logic (no debugging code)
+ */
+
+/**
+ * Determines the API base URL based on search parameters
+ */
+export function getApiBase(
+  useAgoricWebsiteMCP: string | null,
+  theme: string | null
+): string {
+  if (useAgoricWebsiteMCP) {
+    return "/api/support";
+  }
+  if (theme === "ymax") {
+    return "/api/ymax";
+  }
+  return "/api/chat";
+}
+
+/**
+ * Builds the full API URL with query parameters
+ */
+export function buildApiUrl(
+  apiBase: string,
+  queryParams: URLSearchParams
+): string {
+  const queryString = queryParams.toString();
+  return queryString ? `${apiBase}?${queryString}` : apiBase;
+}
+
+/**
+ * Decodes and returns the chat title with a default fallback
+ */
+export function decodeTitle(
+  titleParam: string | null,
+): string {
+  const defaultTitle = "Agoric AI Chat";
+  if (!titleParam) {
+    return defaultTitle;
+  }
+  try {
+    return decodeURIComponent(titleParam);
+  } catch {
+    return defaultTitle;
+  }
+}
+
+/**
+ * Determines if the chat is in a loading state based on status
+ */
+export function isLoadingState(status: string): boolean {
+  return status === "streaming" || status === "submitted";
+}
+
+/**
+ * Safely parses JSON from a message event data
+ */
+export function parseMessageData(data: unknown): unknown {
+  if (typeof data === "string") {
+    try {
+      return JSON.parse(data);
+    } catch {
+      return data;
+    }
+  }
+  return data;
+}
+
+/**
+ * Checks if a message event is an ORBIT_CHAT submission
+ */
+export function isOrbitChatSubmission(
+  data: unknown
+): data is { type: string; payload: { input: string } } {
+  return (
+    typeof data === "object" &&
+    data !== null &&
+    "type" in data &&
+    (data as { type: string }).type === "ORBIT_CHAT/SET_AND_SUBMIT"
+  );
+}
+
+/**
+ * Determines if code should be submitted based on state
+ */
+export function shouldSubmitCode(
+  submittedCode: string | null,
+  submissionKey: number,
+  lastSubmittedKey: number,
+  isLoading: boolean
+): boolean {
+  return (
+    Boolean(submittedCode) &&
+    submissionKey > 0 &&
+    submissionKey !== lastSubmittedKey &&
+    !isLoading
+  );
+}
+
+/**
+ * Builds the new URL for chat navigation after first message
+ */
+export function buildChatUrl(
+  chatId: string,
+  searchParams: URLSearchParams
+): string {
+  const queryString = searchParams.toString();
+  const query = queryString ? `?${queryString}` : "";
+  return `/chat/${chatId}${query}`;
+}

--- a/lib/chat-utils.ts
+++ b/lib/chat-utils.ts
@@ -1,9 +1,4 @@
 /**
- * Utility functions extracted from chat.tsx for testability
- * Only contains actual business logic (no debugging code)
- */
-
-/**
  * Determines the API base URL based on search parameters
  */
 export function getApiBase(

--- a/test/chat-utils.test.ts
+++ b/test/chat-utils.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect } from "vitest";
+import {
+  getApiBase,
+  buildApiUrl,
+  decodeTitle,
+  isLoadingState,
+  parseMessageData,
+  isOrbitChatSubmission,
+  shouldSubmitCode,
+  buildChatUrl,
+} from "@/lib/chat-utils";
+
+describe("chat-utils", () => {
+  describe("getApiBase", () => {
+    it("returns /api/support when useAgoricWebsiteMCP is set", () => {
+      expect(getApiBase("true", null)).toBe("/api/support");
+    });
+
+    it("returns /api/ymax when theme is ymax", () => {
+      expect(getApiBase(null, "ymax")).toBe("/api/ymax");
+    });
+
+    it("returns /api/chat by default", () => {
+      expect(getApiBase(null, null)).toBe("/api/chat");
+    });
+  });
+
+  describe("buildApiUrl", () => {
+    it("returns apiBase when no query params", () => {
+      const params = new URLSearchParams();
+      expect(buildApiUrl("/api/chat", params)).toBe("/api/chat");
+    });
+
+    it("appends query params to apiBase", () => {
+      const params = new URLSearchParams();
+      params.set("context", "test-context");
+      expect(buildApiUrl("/api/chat", params)).toBe(
+        "/api/chat?context=test-context"
+      );
+    });
+
+    it("handles multiple query params", () => {
+      const params = new URLSearchParams();
+      params.set("context", "ctx");
+      params.set("foo", "bar");
+      expect(buildApiUrl("/api/support", params)).toBe(
+        "/api/support?context=ctx&foo=bar"
+      );
+    });
+  });
+
+  describe("decodeTitle", () => {
+    it("returns default title when titleParam is null", () => {
+      expect(decodeTitle(null)).toBe("Agoric AI Chat");
+    });
+
+    it("decodes URL-encoded title", () => {
+      expect(decodeTitle("Hello%20World")).toBe("Hello World");
+      expect(decodeTitle("Test%26Title")).toBe("Test&Title");
+    });
+
+    it("returns default title for invalid encoding", () => {
+      expect(decodeTitle("%E0%A4%A")).toBe("Agoric AI Chat");
+    });
+
+    it("handles empty string", () => {
+      expect(decodeTitle("")).toBe("Agoric AI Chat");
+    });
+  });
+
+  describe("isLoadingState", () => {
+    it("returns true for streaming status", () => {
+      expect(isLoadingState("streaming")).toBe(true);
+    });
+
+    it("returns true for submitted status", () => {
+      expect(isLoadingState("submitted")).toBe(true);
+    });
+
+    it("returns false for idle status", () => {
+      expect(isLoadingState("idle")).toBe(false);
+    });
+
+    it("returns false for error status", () => {
+      expect(isLoadingState("error")).toBe(false);
+    });
+
+    it("returns false for empty string", () => {
+      expect(isLoadingState("")).toBe(false);
+    });
+  });
+
+  describe("parseMessageData", () => {
+    it("parses valid JSON string", () => {
+      expect(parseMessageData('{"type":"test"}')).toEqual({ type: "test" });
+    });
+
+    it("returns original string for invalid JSON", () => {
+      expect(parseMessageData("not json")).toBe("not json");
+    });
+
+    it("returns non-string data as-is", () => {
+      const obj = { foo: "bar" };
+      expect(parseMessageData(obj)).toBe(obj);
+    });
+
+    it("handles null", () => {
+      expect(parseMessageData(null)).toBe(null);
+    });
+
+    it("handles arrays", () => {
+      const arr = [1, 2, 3];
+      expect(parseMessageData(arr)).toBe(arr);
+    });
+
+    it("parses nested JSON", () => {
+      const json = '{"payload":{"input":"test"}}';
+      expect(parseMessageData(json)).toEqual({ payload: { input: "test" } });
+    });
+  });
+
+  describe("isOrbitChatSubmission", () => {
+    it("returns true for valid ORBIT_CHAT/SET_AND_SUBMIT message", () => {
+      const data = {
+        type: "ORBIT_CHAT/SET_AND_SUBMIT",
+        payload: { input: "test" },
+      };
+      expect(isOrbitChatSubmission(data)).toBe(true);
+    });
+
+    it("returns false for different type", () => {
+      const data = { type: "OTHER_TYPE", payload: { input: "test" } };
+      expect(isOrbitChatSubmission(data)).toBe(false);
+    });
+
+    it("returns false for string", () => {
+      expect(isOrbitChatSubmission("string")).toBe(false);
+    });
+
+    it("returns false for object without type", () => {
+      expect(isOrbitChatSubmission({ payload: { input: "test" } })).toBe(false);
+    });
+
+  });
+
+  describe("shouldSubmitCode", () => {
+    it("returns true when all conditions are met", () => {
+      expect(shouldSubmitCode("code", 5, 4, false)).toBe(true);
+    });
+
+    it("returns false when submittedCode is null", () => {
+      expect(shouldSubmitCode(null, 1, 0, false)).toBe(false);
+    });
+
+    it("returns false when submittedCode is empty string", () => {
+      expect(shouldSubmitCode("", 1, 0, false)).toBe(false);
+    });
+
+    it("returns false when submissionKey is 0", () => {
+      expect(shouldSubmitCode("code", 0, 0, false)).toBe(false);
+    });
+
+    it("returns false when submissionKey equals lastSubmittedKey", () => {
+      expect(shouldSubmitCode("code", 5, 5, false)).toBe(false);
+    });
+
+    it("returns false when isLoading is true", () => {
+      expect(shouldSubmitCode("code", 1, 0, true)).toBe(false);
+    });
+  });
+
+  describe("buildChatUrl", () => {
+    it("builds URL without query params", () => {
+      const params = new URLSearchParams();
+      expect(buildChatUrl("abc123", params)).toBe("/chat/abc123");
+    });
+
+    it("builds URL with query params", () => {
+      const params = new URLSearchParams();
+      params.set("context", "test");
+      expect(buildChatUrl("abc123", params)).toBe("/chat/abc123?context=test");
+    });
+
+    it("builds URL with multiple query params", () => {
+      const params = new URLSearchParams();
+      params.set("theme", "ymax");
+      params.set("context", "ctx");
+      expect(buildChatUrl("xyz789", params)).toBe(
+        "/chat/xyz789?theme=ymax&context=ctx"
+      );
+    });
+
+    it("handles special characters in chatId", () => {
+      const params = new URLSearchParams();
+      expect(buildChatUrl("abc-123_xyz", params)).toBe("/chat/abc-123_xyz");
+    });
+  });
+});


### PR DESCRIPTION
Extracted 8 pure utility functions from chat.tsx into a separate lib/chat-utils.ts module for improved testability and maintainability:
**getApiBase** - Determines API endpoint based on URL params
**buildApiUrl** - Constructs API URL with query parameters
**decodeTitle** - Safely decodes URL-encoded page titles
**isLoadingState** - Checks if chat is in loading state
**parseMessageData** - Safely parses JSON from message events
**isOrbitChatSubmission** - Type guard for ORBIT_CHAT messages
**shouldSubmitCode** - Validates code submission conditions
**buildChatUrl** - Builds chat navigation URLs
Added 35 unit tests covering all utility functions with edge cases.